### PR TITLE
Execute elm-format in Elm Root

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ merge requests are welcome. Changes so far:
 - Improvements to the `gf` binding to handle prefixed function calls and module aliases. It also
   attempts to take you to the line of the function in question though that is behaviour normally
   associated with `C-]`. It might be moved at some point.
+- Always execute `elm-format` in the project root so it can detect the elm version appropriately.
 
 
 ## Features

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -61,7 +61,7 @@ function! elm#Format() abort
   call writefile(getline(1, '$'), l:tmpname)
 
   " call elm-format on the temporary file
-  let l:out = system('elm-format ' . l:tmpname . ' --output ' . l:tmpname)
+  let l:out = s:ExecuteInRoot('elm-format ' . l:tmpname . ' --output ' . l:tmpname)
 
   " if there is no error
   if v:shell_error == 0


### PR DESCRIPTION
Hi! Can https://github.com/ElmCast/elm-vim/pull/169 be merged into this repo?

> As mentioned in #166 there is still an issue when running `elm-format`.
> This PR runs `elm-format` in the folder where elm(-package).json is found.

