### PR TITLE
 Syntax: Add elm module group

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -347,11 +347,14 @@ function! elm#FindRootDirectory() abort
 	if empty(l:elm_root)
 		let l:current_file = expand('%:p')
 		let l:dir_current_file = fnameescape(fnamemodify(l:current_file, ':h'))
-		let l:match = findfile('elm-package.json', l:dir_current_file . ';')
-		if empty(l:match)
-			let l:elm_root = ''
+		let l:old_match = findfile('elm-package.json', l:dir_current_file . ';')
+		let l:new_match = findfile('elm.json', l:dir_current_file . ';')
+		if !empty(l:new_match)
+			let l:elm_root = fnamemodify(l:new_match, ':p:h')
+		elseif !empty(l:old_match)
+			let l:elm_root = fnamemodify(l:old_match, ':p:h')
 		else
-			let l:elm_root = fnamemodify(l:match, ':p:h')
+			let l:elm_root = ''
 		endif
 
 		if !empty(l:elm_root)

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -41,14 +41,26 @@ setlocal comments=:--
 setlocal commentstring=--\ %s
 
 " Commands
-command! -buffer -nargs=? -complete=file ElmMake call elm#Make(<f-args>)
-command! -buffer ElmMakeMain call elm#Make("Main.elm")
-command! -buffer -nargs=? -complete=file ElmTest call elm#Test(<f-args>)
-command! -buffer ElmRepl call elm#Repl()
-command! -buffer ElmErrorDetail call elm#ErrorDetail()
-command! -buffer ElmShowDocs call elm#ShowDocs()
-command! -buffer ElmBrowseDocs call elm#BrowseDocs()
-command! -buffer ElmFormat call elm#Format()
+command -buffer -nargs=? -complete=file ElmMake call elm#Make(<f-args>)
+command -buffer ElmMakeMain call elm#Make("Main.elm")
+command -buffer -nargs=? -complete=file ElmTest call elm#Test(<f-args>)
+command -buffer ElmRepl call elm#Repl()
+command -buffer ElmErrorDetail call elm#ErrorDetail()
+command -buffer ElmShowDocs call elm#ShowDocs()
+command -buffer ElmBrowseDocs call elm#BrowseDocs()
+command -buffer ElmFormat call elm#Format()
+
+" Commands cleanup
+let b:undo_ftplugin = "
+      \ delcommand ElmMake
+      \|delcommand ElmMakeMain
+      \|delcommand ElmTest
+      \|delcommand ElmRepl
+      \|delcommand ElmErrorDetail
+      \|delcommand ElmShowDocs
+      \|delcommand ElmBrowseDocs
+      \|delcommand ElmFormat
+      \"
 
 if get(g:, 'elm_setup_keybindings', 1)
   nmap <buffer> <LocalLeader>m <Plug>(elm-make)

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -41,14 +41,14 @@ setlocal comments=:--
 setlocal commentstring=--\ %s
 
 " Commands
-command -buffer -nargs=? -complete=file ElmMake call elm#Make(<f-args>)
-command -buffer ElmMakeMain call elm#Make("Main.elm")
-command -buffer -nargs=? -complete=file ElmTest call elm#Test(<f-args>)
-command -buffer ElmRepl call elm#Repl()
-command -buffer ElmErrorDetail call elm#ErrorDetail()
-command -buffer ElmShowDocs call elm#ShowDocs()
-command -buffer ElmBrowseDocs call elm#BrowseDocs()
-command -buffer ElmFormat call elm#Format()
+command! -buffer -nargs=? -complete=file ElmMake call elm#Make(<f-args>)
+command! -buffer ElmMakeMain call elm#Make("Main.elm")
+command! -buffer -nargs=? -complete=file ElmTest call elm#Test(<f-args>)
+command! -buffer ElmRepl call elm#Repl()
+command! -buffer ElmErrorDetail call elm#ErrorDetail()
+command! -buffer ElmShowDocs call elm#ShowDocs()
+command! -buffer ElmBrowseDocs call elm#BrowseDocs()
+command! -buffer ElmFormat call elm#Format()
 
 if get(g:, 'elm_setup_keybindings', 1)
   nmap <buffer> <LocalLeader>m <Plug>(elm-make)

--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -5,13 +5,13 @@ if exists('b:current_syntax')
 endif
 
 " Keywords
-syn keyword elmConditional case else if of then
+syn keyword elmConditional else if of then
 syn keyword elmAlias alias
-syn keyword elmTypedef type port let in
+syn keyword elmTypedef contained type port
 syn keyword elmImport exposing as import module where
 
 " Operators
-syn match elmOperator "\([-!#$%`&\*\+./<=>\?@\\^|~:]\|\<_\>\)"
+syn match elmOperator contained "\([-!#$%`&\*\+./<=>\?@\\^|~:]\|\<_\>\)"
 
 " Types
 syn match elmType "\<[A-Z][0-9A-Za-z_'-]*"
@@ -27,7 +27,7 @@ syn match elmTupleFunction "\((,\+)\)"
 " Comments
 syn keyword elmTodo TODO FIXME XXX contained
 syn match elmLineComment "--.*" contains=elmTodo,@spell
-syn region elmComment matchgroup=elmComment start="{-|\=" end="-}" contains=elmTodo,elmComment,@spell
+syn region elmComment matchgroup=elmComment start="{-|\=" end="-}" contains=elmTodo,elmComment,@spell fold
 
 " Strings
 syn match elmStringEscape "\\u[0-9a-fA-F]\{4}" contained
@@ -43,6 +43,16 @@ syn match elmFloat "\(\<\d\+\.\d\+\>\)"
 " Identifiers
 syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\s\+" contains=elmOperator
 
+" Folding
+syn region elmTopLevelTypedef start="type" end="\n\(\n\n\)\@=" contains=ALL fold
+syn region elmTopLevelFunction start="^[a-zA-Z].\+\n[a-zA-Z].\+=" end="^\(\n\+\)\@=" contains=ALL fold
+syn region elmCaseBlock matchgroup=elmCaseBlockDefinition start="^\z\(\s\+\)\<case\>" end="^\z1\@!\W\@=" end="\(\n\n\z1\@!\)\@=" end="\n\z1\@!\(\n\n\)\@=" contains=ALL fold
+syn region elmCaseItemBlock start="^\z\(\s\+\).\+->$" end="^\z1\@!\W\@=" end="\(\n\n\z1\@!\)\@=" end="\(\n\z1\S\)\@=" contains=ALL fold
+syn region elmLetBlock matchgroup=elmLetBlockDefinition start="\<let\>" end="\<in\>" contains=ALL fold
+
+hi def link elmCaseBlockDefinition Conditional
+hi def link elmCaseBlockItemDefinition Conditional
+hi def link elmLetBlockDefinition TypeDef
 hi def link elmTopLevelDecl Function
 hi def link elmTupleFunction Normal
 hi def link elmTodo Todo

--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -8,7 +8,7 @@ endif
 syn keyword elmConditional else if of then
 syn keyword elmAlias alias
 syn keyword elmTypedef contained type port
-syn keyword elmImport exposing as import module where
+syn keyword elmImport contained exposing as import module where
 
 " Operators
 syn match elmOperator contained "\([-!#$%`&\*\+./<=>\?@\\^|~:]\|\<_\>\)"
@@ -16,6 +16,10 @@ syn match elmOperator contained "\([-!#$%`&\*\+./<=>\?@\\^|~:]\|\<_\>\)"
 " Types
 syn match elmType "\<[A-Z][0-9A-Za-z_'-]*"
 syn keyword elmNumberType number
+
+" Modules
+syn match elmModule "\<\([A-Z][0-9A-Za-z_'-\.]*\)\+\.[A-Za-z]"me=e-2
+syn match elmModule "^\(module\|import\)\s\+[A-Z][0-9A-Za-z_'-\.]*\(\s\+as\s\+[A-Z][0-9A-Za-z_'-\.]*\)\?\(\s\+exposing\)\?" contains=elmImport
 
 " Delimiters
 syn match elmDelimiter  "[,;]"
@@ -73,6 +77,7 @@ hi def link elmAlias Delimiter
 hi def link elmOperator Operator
 hi def link elmType Identifier
 hi def link elmNumberType Identifier
+hi def link elmModule Type
 
 syn sync minlines=500
 

--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -41,7 +41,7 @@ syn match elmInt "-\?\<\d\+\>\|0[xX][0-9a-fA-F]\+\>"
 syn match elmFloat "\(\<\d\+\.\d\+\>\)"
 
 " Identifiers
-syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\s\+" contains=elmOperator
+syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\(\r\n\|\r\|\n\|\s\)\+" contains=elmOperator
 
 " Folding
 syn region elmTopLevelTypedef start="type" end="\n\(\n\n\)\@=" contains=ALL fold


### PR DESCRIPTION
Why
---

I want to be able to differentiate Elm modules from Elm types

How
---

* Create `elmModule` highlight group
* Link `elmModule` to `Type`, the group conventionally used for modules

Side effects
------------

This PR brings the fork up-to-date with upstream, which may or may not be desirable. The `
Syntax: Add elm module group` commit may be cherry-picked.