### PR TITLE
[feat/add-elm-format-options]

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ let g:elm_browser_command = ""
 let g:elm_detailed_complete = 0
 let g:elm_format_autosave = 1
 let g:elm_format_fail_silently = 0
+let g:elm_format_options = ""
 let g:elm_setup_keybindings = 1
 ```
 
@@ -139,7 +140,7 @@ let g:elm_setup_keybindings = 1
 
 * `:ElmMakeMain` attempts to call `elm-make` with "Main.elm".
 
-* `:ElmTest` calls `elm-test` with the given file. If no file is given it runs it in the root of your project. 
+* `:ElmTest` calls `elm-test` with the given file. If no file is given it runs it in the root of your project.
 
 * `:ElmRepl` runs `elm-repl`, which will return to vim on exiting.
 

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -60,8 +60,10 @@ function! elm#Format() abort
   let l:tmpname = tempname() . '.elm'
   call writefile(getline(1, '$'), l:tmpname)
 
+  let l:format_options = get(g:, 'elm_format_options', "")
+
   " call elm-format on the temporary file
-  let l:out = s:ExecuteInRoot('elm-format ' . l:tmpname . ' --output ' . l:tmpname)
+  let l:out = s:ExecuteInRoot('elm-format ' . l:format_options . ' ' . l:tmpname . ' --output ' . l:tmpname)
 
   " if there is no error
   if v:shell_error == 0

--- a/doc/elm-vim.txt
+++ b/doc/elm-vim.txt
@@ -87,7 +87,7 @@ COMMANDS                                                         *elm-commands*
 :ElmTest [file]
 
     ElmTest calls `elm-test` with the given {file}. If no {file} is given
-    it runs it in the root of your project. 
+    it runs it in the root of your project.
 
 :ElmRepl
 
@@ -215,6 +215,12 @@ This setting toggles whether format errors show be display.
 >
   let g:elm_format_fail_silently = 0
 <
+
+                                                       *'g:elm_format_options'*
+
+This setting allows you to pass in additional `elm-format` command-line options.
+>
+  let g:elm_format_options = ""
 
 
 ===============================================================================

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -31,6 +31,10 @@ if !exists('g:elm_format_fail_silently')
     let g:elm_format_fail_silently = 0
 endif
 
+if !exists('g:elm_format_options')
+    let g:elm_format_options = ""
+endif
+
 if !exists('g:elm_setup_keybindings')
 	let g:elm_setup_keybindings = 1
 endif


### PR DESCRIPTION
Adds ability to pass in command-line options to `elm-format` (:ElmFormat).

This is useful, to set the `--elm-version` option for `0.18` users, for instance. Let me know if this makes more sense to just have an explicit option like `g:elm_format_version` for this, so it doesn't interfere with the order of operations for the temp file creation and output.